### PR TITLE
Bugfix/9 should use show stream for get table names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,6 @@ build:
 
 install: build
 	python3 -m pip install --upgrade dist/timeplus_connect-$(VERSION).tar.gz
+
+lint:
+	pylint --rcfile=./pylintrc  timeplus_connect

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+VERSION := $(shell git describe --tags --abbrev=0 | sed 's/^v//')
+
+version:
+	echo "Version: $(VERSION)"
+
+build:
+	python3 -m pip install --upgrade build
+	python3 -m build
+
+install: build
+	python3 -m pip install --upgrade dist/timeplus_connect-$(VERSION).tar.gz

--- a/test_dist/llamaIndex_dbreader.py
+++ b/test_dist/llamaIndex_dbreader.py
@@ -1,0 +1,33 @@
+from llama_index.readers.database import DatabaseReader
+from llama_index.core import VectorStoreIndex
+import timeplus_connect
+client: timeplus_connect.driver.Client
+
+from sqlalchemy.engine import create_engine
+
+# Ensure the timeplus-connect driver is registered
+TIMEPLUS_URI = "timeplus://user:password@localhost:8123"
+
+# Create SQLAlchemy engine explicitly
+engine = create_engine(TIMEPLUS_URI)
+
+db_reader = DatabaseReader(
+    engine=engine  # Use the explicit SQLAlchemy engine
+)
+
+print(f"db reader type: {type(db_reader)}")
+print(type(db_reader.load_data))
+
+### SQLDatabase class ###
+# db.sql is an instance of SQLDatabase:
+print(type(db_reader.sql_database))
+# SQLDatabase available methods:
+print(type(db_reader.sql_database.from_uri))
+print(type(db_reader.sql_database.get_single_table_info))
+print(type(db_reader.sql_database.get_table_columns))
+print(type(db_reader.sql_database.get_usable_table_names))
+print(type(db_reader.sql_database.insert_into_table))
+print(type(db_reader.sql_database.run_sql))
+# SQLDatabase available properties:
+print(type(db_reader.sql_database.dialect))
+print(type(db_reader.sql_database.engine))

--- a/test_dist/llamaIndex_dbreader.py
+++ b/test_dist/llamaIndex_dbreader.py
@@ -1,18 +1,11 @@
 from llama_index.readers.database import DatabaseReader
-from llama_index.core import VectorStoreIndex
 import timeplus_connect
-client: timeplus_connect.driver.Client
 
-from sqlalchemy.engine import create_engine
 
 # Ensure the timeplus-connect driver is registered
 TIMEPLUS_URI = "timeplus://user:password@localhost:8123"
-
-# Create SQLAlchemy engine explicitly
-engine = create_engine(TIMEPLUS_URI)
-
 db_reader = DatabaseReader(
-    engine=engine  # Use the explicit SQLAlchemy engine
+    uri=TIMEPLUS_URI  # Use the explicit SQLAlchemy engine
 )
 
 print(f"db reader type: {type(db_reader)}")

--- a/timeplus_connect/cc_sqlalchemy/ddl/tableengine.py
+++ b/timeplus_connect/cc_sqlalchemy/ddl/tableengine.py
@@ -266,7 +266,7 @@ def build_engine(full_engine: str) -> Optional[TableEngine]:
         engine_cls = engine_map[name]
     except KeyError:
         if not name.startswith('System'):
-            logger.warning('Engine %s not found', name)
+            logger.warning('Engine %s not found, full_engine: %s', name, full_engine)
         return None
     engine = engine_cls.__new__(engine_cls)
     engine.name = name

--- a/timeplus_connect/cc_sqlalchemy/dialect.py
+++ b/timeplus_connect/cc_sqlalchemy/dialect.py
@@ -11,6 +11,7 @@ from timeplus_connect.cc_sqlalchemy import ischema_names, dialect_name
 from timeplus_connect.cc_sqlalchemy.sql.preparer import TpIdentifierPreparer
 from timeplus_connect.driver.binding import quote_identifier, format_str
 
+
 # pylint: disable=too-many-public-methods,no-self-use,unused-argument
 class TimeplusDialect(DefaultDialect):
     """

--- a/timeplus_connect/cc_sqlalchemy/dialect.py
+++ b/timeplus_connect/cc_sqlalchemy/dialect.py
@@ -64,30 +64,8 @@ class TimeplusDialect(DefaultDialect):
         return [row.name for row in connection.execute(cmd)]
 
     def get_columns(self, connection, table_name, schema=None, **kwargs):
-        if schema is None:
-            schema = 'default'
-
-        table_id = full_table(table_name, schema)
-        query = text(f"DESCRIBE {table_id}")
-
-        result_set = connection.execute(query)
-        if not result_set:
-            raise NoResultFound(f'STREAM {full_table} does not exist')
-        columns = []
-        for row in result_set:
-            sqla_type = sqla_type_from_name(row.type.replace('\n', ''))
-            col = {'name': row.name,
-                   'type': sqla_type,
-                   'nullable': sqla_type.nullable,
-                   'autoincrement': False,
-                   'default': row.default_expression,
-                   'default_type': row.default_type,
-                   'comment': row.comment,
-                   'codec_expression': row.codec_expression,
-                   'ttl_expression': row.ttl_expression}
-            columns.append(col)
-        return columns
-
+        inspector = self.inspector(connection)
+        return inspector.get_columns(table_name, schema, **kwargs)
 
     def get_primary_keys(self, connection, table_name, schema=None, **kw):
         return []

--- a/timeplus_connect/cc_sqlalchemy/dialect.py
+++ b/timeplus_connect/cc_sqlalchemy/dialect.py
@@ -1,5 +1,8 @@
 
 from sqlalchemy.engine.default import DefaultDialect
+from sqlalchemy.sql import text
+from sqlalchemy import types, util
+from sqlalchemy.orm.exc import NoResultFound
 
 from timeplus_connect import dbapi
 
@@ -9,7 +12,7 @@ from timeplus_connect.cc_sqlalchemy.sql.ddlcompiler import TpDDLCompiler
 from timeplus_connect.cc_sqlalchemy import ischema_names, dialect_name
 from timeplus_connect.cc_sqlalchemy.sql.preparer import TpIdentifierPreparer
 from timeplus_connect.driver.binding import quote_identifier, format_str
-
+from timeplus_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name
 
 # pylint: disable=too-many-public-methods,no-self-use,unused-argument
 class TimeplusDialect(DefaultDialect):
@@ -36,6 +39,10 @@ class TimeplusDialect(DefaultDialect):
     @classmethod
     def dbapi(cls):
         return dbapi
+    
+    @classmethod
+    def import_dbapi(cls):
+        return dbapi
 
     def initialize(self, connection):
         pass
@@ -50,10 +57,37 @@ class TimeplusDialect(DefaultDialect):
                                    f'WHERE name = {format_str(db_name)}')).rowcount > 0
 
     def get_table_names(self, connection, schema=None, **kw):
-        cmd = 'SHOW STREAMS'
+        cmd = text('SHOW STREAMS')  # Wrap in text() to make it an executable SQLAlchemy statement
         if schema:
-            cmd += ' FROM ' + quote_identifier(schema)
+            cmd = text(f"SHOW STREAMS FROM {quote_identifier(schema)}")  # Ensure schema is properly quoted
+
         return [row.name for row in connection.execute(cmd)]
+    
+    def get_columns(self, connection, table_name, schema=None, **kwargs):
+        if schema is None:
+            schema = 'default'
+            
+        table_id = full_table(table_name, schema)
+        query = text(f"DESCRIBE {table_id}")
+        
+        result_set = connection.execute(query)
+        if not result_set:
+            raise NoResultFound(f'STREAM {full_table} does not exist')
+        columns = []
+        for row in result_set:
+            sqla_type = sqla_type_from_name(row.type.replace('\n', ''))
+            col = {'name': row.name,
+                   'type': sqla_type,
+                   'nullable': sqla_type.nullable,
+                   'autoincrement': False,
+                   'default': row.default_expression,
+                   'default_type': row.default_type,
+                   'comment': row.comment,
+                   'codec_expression': row.codec_expression,
+                   'ttl_expression': row.ttl_expression}
+            columns.append(col)
+        return columns
+
 
     def get_primary_keys(self, connection, table_name, schema=None, **kw):
         return []

--- a/timeplus_connect/cc_sqlalchemy/dialect.py
+++ b/timeplus_connect/cc_sqlalchemy/dialect.py
@@ -1,7 +1,6 @@
 
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.sql import text
-from sqlalchemy import types, util
 from sqlalchemy.orm.exc import NoResultFound
 
 from timeplus_connect import dbapi

--- a/timeplus_connect/cc_sqlalchemy/dialect.py
+++ b/timeplus_connect/cc_sqlalchemy/dialect.py
@@ -39,7 +39,7 @@ class TimeplusDialect(DefaultDialect):
     @classmethod
     def dbapi(cls):
         return dbapi
-    
+
     @classmethod
     def import_dbapi(cls):
         return dbapi
@@ -49,7 +49,8 @@ class TimeplusDialect(DefaultDialect):
 
     @staticmethod
     def get_schema_names(connection, **_):
-        return [row.name for row in connection.execute('SHOW DATABASES')]
+        query = text('SHOW DATABASES')
+        return [row.name for row in connection.execute(query)]
 
     @staticmethod
     def has_database(connection, db_name):
@@ -62,14 +63,14 @@ class TimeplusDialect(DefaultDialect):
             cmd = text(f"SHOW STREAMS FROM {quote_identifier(schema)}")  # Ensure schema is properly quoted
 
         return [row.name for row in connection.execute(cmd)]
-    
+
     def get_columns(self, connection, table_name, schema=None, **kwargs):
         if schema is None:
             schema = 'default'
-            
+
         table_id = full_table(table_name, schema)
         query = text(f"DESCRIBE {table_id}")
-        
+
         result_set = connection.execute(query)
         if not result_set:
             raise NoResultFound(f'STREAM {full_table} does not exist')

--- a/timeplus_connect/cc_sqlalchemy/dialect.py
+++ b/timeplus_connect/cc_sqlalchemy/dialect.py
@@ -1,7 +1,6 @@
 
 from sqlalchemy.engine.default import DefaultDialect
 from sqlalchemy.sql import text
-from sqlalchemy.orm.exc import NoResultFound
 
 from timeplus_connect import dbapi
 
@@ -11,7 +10,6 @@ from timeplus_connect.cc_sqlalchemy.sql.ddlcompiler import TpDDLCompiler
 from timeplus_connect.cc_sqlalchemy import ischema_names, dialect_name
 from timeplus_connect.cc_sqlalchemy.sql.preparer import TpIdentifierPreparer
 from timeplus_connect.driver.binding import quote_identifier, format_str
-from timeplus_connect.cc_sqlalchemy.datatypes.base import sqla_type_from_name
 
 # pylint: disable=too-many-public-methods,no-self-use,unused-argument
 class TimeplusDialect(DefaultDialect):

--- a/timeplus_connect/cc_sqlalchemy/inspector.py
+++ b/timeplus_connect/cc_sqlalchemy/inspector.py
@@ -39,6 +39,9 @@ class TpInspector(Inspector):
         table.engine = get_engine(self.bind, table.name, schema)
 
     def get_columns(self, table_name, schema=None, **_kwargs):
+        if schema is None:
+            schema = 'default'
+            
         table_id = full_table(table_name, schema)
         query = text(f"DESCRIBE {table_id}")
 

--- a/timeplus_connect/cc_sqlalchemy/inspector.py
+++ b/timeplus_connect/cc_sqlalchemy/inspector.py
@@ -41,7 +41,7 @@ class TpInspector(Inspector):
     def get_columns(self, table_name, schema=None, **_kwargs):
         if schema is None:
             schema = 'default'
-            
+
         table_id = full_table(table_name, schema)
         query = text(f"DESCRIBE {table_id}")
 

--- a/timeplus_connect/cc_sqlalchemy/inspector.py
+++ b/timeplus_connect/cc_sqlalchemy/inspector.py
@@ -15,9 +15,9 @@ ch_col_args = ('default_type', 'codec_expression', 'ttl_expression')
 def get_engine(connection, table_name, schema=None):
     if schema is None:
         schema = 'default'
-        
+
     query = text(f"SELECT engine_full FROM system.tables WHERE database = '{schema}' and name = '{table_name}'")
-    
+
     result_set = connection.execute(query)
     row = next(result_set, None)
     if not row:
@@ -41,7 +41,7 @@ class TpInspector(Inspector):
     def get_columns(self, table_name, schema=None, **_kwargs):
         table_id = full_table(table_name, schema)
         query = text(f"DESCRIBE {table_id}")
-        
+
         result_set = self.bind.execute(query)
         if not result_set:
             raise NoResultFound(f'STREAM {full_table} does not exist')


### PR DESCRIPTION
There are couple of fix to support integration with llamaIndex

1. should use text() to wrap queries
2. add missing method get_columns in dialect
3. set default schema (database) to 'default' when it is not specificed

there are more test need to be verified later for
1. schema handling , and add schem in the uri
2. verify following method: from_uri,get_single_table_info,get_table_columns,get_usable_table_names,insert_into_table,run_sql
3. handle those engines introduce by timeplus - stream, external stream etc , now there will be warnings

